### PR TITLE
fix(api): atomic primitives close three race conditions (#11)

### DIFF
--- a/apps/api/src/memory/__tests__/conversation.test.ts
+++ b/apps/api/src/memory/__tests__/conversation.test.ts
@@ -9,7 +9,11 @@ let mockInsertCalled = false;
 let mockUpdateCalled = false;
 let mockOnConflictCalled = false;
 let mockTransactionCalled = false;
-let mockReturningRow: { messages: ConversationMessage[] } = { messages: [] };
+let mockSelectCalled = false;
+let mockReturningRow: { messages: ConversationMessage[]; xmax?: string } = {
+  messages: [],
+  xmax: '0',
+};
 
 function chainable(getRows: () => unknown[]): unknown {
   const methods: Record<string, unknown> = {};
@@ -21,7 +25,10 @@ function chainable(getRows: () => unknown[]): unknown {
 
 function buildTxLike(): unknown {
   return {
-    select: () => chainable(() => mockSelectRows),
+    select: () => {
+      mockSelectCalled = true;
+      return chainable(() => mockSelectRows);
+    },
     insert: () => ({
       values: () => {
         mockInsertCalled = true;
@@ -46,7 +53,10 @@ function buildTxLike(): unknown {
 
 mock.module('../../db', () => ({
   getDb: () => ({
-    select: () => chainable(() => mockSelectRows),
+    select: () => {
+      mockSelectCalled = true;
+      return chainable(() => mockSelectRows);
+    },
     insert: () => ({
       values: () => {
         mockInsertCalled = true;
@@ -85,7 +95,8 @@ describe('ConversationMemory', () => {
     mockUpdateCalled = false;
     mockOnConflictCalled = false;
     mockTransactionCalled = false;
-    mockReturningRow = { messages: [] };
+    mockSelectCalled = false;
+    mockReturningRow = { messages: [], xmax: '0' };
   });
 
   afterEach(() => {
@@ -94,7 +105,8 @@ describe('ConversationMemory', () => {
     mockUpdateCalled = false;
     mockOnConflictCalled = false;
     mockTransactionCalled = false;
-    mockReturningRow = { messages: [] };
+    mockSelectCalled = false;
+    mockReturningRow = { messages: [], xmax: '0' };
   });
 
   describe('getHistory', () => {
@@ -149,7 +161,7 @@ describe('ConversationMemory', () => {
         content: 'Hello',
         timestamp: '2026-01-01T00:00:00Z',
       };
-      mockReturningRow = { messages: [msg] };
+      mockReturningRow = { messages: [msg], xmax: '0' };
       const result = await memory.append(CHANNEL_ID, THREAD_ID, msg);
       expect(result.tokenCount).toBeGreaterThan(0);
       expect(mockTransactionCalled).toBe(true);
@@ -164,12 +176,15 @@ describe('ConversationMemory', () => {
         content: 'Hello',
         timestamp: '2026-01-01T00:00:00Z',
       };
-      mockReturningRow = { messages: [msg] };
+      mockReturningRow = { messages: [msg], xmax: '0' };
       await memory.append(CHANNEL_ID, THREAD_ID, msg);
       // Insert was the first DB action; no read-modify-write select happened
       // before it (the prior implementation always selected first).
       expect(mockInsertCalled).toBe(true);
       expect(mockOnConflictCalled).toBe(true);
+      // Guards against regressing back to read-modify-write — `mockSelectCalled`
+      // is set by both the top-level `getDb().select` and the in-tx `select`.
+      expect(mockSelectCalled).toBe(false);
     });
 
     test('recomputes token count from the merged messages returned by ON CONFLICT', async () => {
@@ -179,9 +194,11 @@ describe('ConversationMemory', () => {
         timestamp: '2026-01-01T00:00:01Z',
       };
       // Simulate the merged JSONB result returned by Postgres after the
-      // server-side concat: an existing message plus our new one.
+      // server-side concat: an existing message plus our new one. xmax is
+      // non-zero on the conflict-update path, which gates the recompute.
       mockReturningRow = {
         messages: [{ role: 'user', content: 'Hello', timestamp: '2026-01-01T00:00:00Z' }, newMsg],
+        xmax: '12345',
       };
       const result = await memory.append(CHANNEL_ID, THREAD_ID, newMsg);
       // Token count should be > the count of just the new message alone
@@ -191,12 +208,26 @@ describe('ConversationMemory', () => {
       expect(mockUpdateCalled).toBe(true);
     });
 
+    test('skips redundant token_count UPDATE on the no-conflict insert path', async () => {
+      const msg: ConversationMessage = {
+        role: 'user',
+        content: 'Fresh thread.',
+        timestamp: '2026-01-01T00:00:00Z',
+      };
+      // xmax = '0' means INSERT actually inserted (no conflict): the VALUES
+      // clause already wrote tokenCount, so the follow-up UPDATE must NOT run.
+      mockReturningRow = { messages: [msg], xmax: '0' };
+      const result = await memory.append(CHANNEL_ID, THREAD_ID, msg);
+      expect(result.tokenCount).toBe(Math.ceil(msg.content.length / 4));
+      expect(mockUpdateCalled).toBe(false);
+    });
+
     test('handles multiple messages in a single append', async () => {
       const msgs: ConversationMessage[] = [
         { role: 'user', content: 'What is 2+2?', timestamp: '2026-01-01T00:00:00Z' },
         { role: 'assistant', content: 'It is 4.', timestamp: '2026-01-01T00:00:01Z' },
       ];
-      mockReturningRow = { messages: msgs };
+      mockReturningRow = { messages: msgs, xmax: '0' };
       const result = await memory.append(CHANNEL_ID, THREAD_ID, ...msgs);
       expect(result.tokenCount).toBeGreaterThan(0);
     });

--- a/apps/api/src/memory/__tests__/conversation.test.ts
+++ b/apps/api/src/memory/__tests__/conversation.test.ts
@@ -7,6 +7,9 @@ const THREAD_ID = 'thread-001';
 let mockSelectRows: unknown[] = [];
 let mockInsertCalled = false;
 let mockUpdateCalled = false;
+let mockOnConflictCalled = false;
+let mockTransactionCalled = false;
+let mockReturningRow: { messages: ConversationMessage[] } = { messages: [] };
 
 function chainable(getRows: () => unknown[]): unknown {
   const methods: Record<string, unknown> = {};
@@ -16,13 +19,20 @@ function chainable(getRows: () => unknown[]): unknown {
   return Object.assign([...getRows()], methods);
 }
 
-mock.module('../../db', () => ({
-  getDb: () => ({
+function buildTxLike(): unknown {
+  return {
     select: () => chainable(() => mockSelectRows),
     insert: () => ({
       values: () => {
         mockInsertCalled = true;
-        return { returning: () => [] };
+        const obj: Record<string, unknown> = {
+          returning: () => [mockReturningRow],
+          onConflictDoUpdate: () => {
+            mockOnConflictCalled = true;
+            return obj;
+          },
+        };
+        return obj;
       },
     }),
     update: () => ({
@@ -31,6 +41,35 @@ mock.module('../../db', () => ({
         return chainable(() => []);
       },
     }),
+  };
+}
+
+mock.module('../../db', () => ({
+  getDb: () => ({
+    select: () => chainable(() => mockSelectRows),
+    insert: () => ({
+      values: () => {
+        mockInsertCalled = true;
+        const obj: Record<string, unknown> = {
+          returning: () => [mockReturningRow],
+          onConflictDoUpdate: () => {
+            mockOnConflictCalled = true;
+            return obj;
+          },
+        };
+        return obj;
+      },
+    }),
+    update: () => ({
+      set: () => {
+        mockUpdateCalled = true;
+        return chainable(() => []);
+      },
+    }),
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+      mockTransactionCalled = true;
+      return cb(buildTxLike());
+    },
   }),
 }));
 
@@ -44,12 +83,18 @@ describe('ConversationMemory', () => {
     mockSelectRows = [];
     mockInsertCalled = false;
     mockUpdateCalled = false;
+    mockOnConflictCalled = false;
+    mockTransactionCalled = false;
+    mockReturningRow = { messages: [] };
   });
 
   afterEach(() => {
     mockSelectRows = [];
     mockInsertCalled = false;
     mockUpdateCalled = false;
+    mockOnConflictCalled = false;
+    mockTransactionCalled = false;
+    mockReturningRow = { messages: [] };
   });
 
   describe('getHistory', () => {
@@ -98,45 +143,60 @@ describe('ConversationMemory', () => {
   });
 
   describe('append', () => {
-    test('creates new conversation when none exists', async () => {
-      mockSelectRows = [];
+    test('runs in a transaction with INSERT ... ON CONFLICT', async () => {
       const msg: ConversationMessage = {
         role: 'user',
         content: 'Hello',
         timestamp: '2026-01-01T00:00:00Z',
       };
+      mockReturningRow = { messages: [msg] };
       const result = await memory.append(CHANNEL_ID, THREAD_ID, msg);
       expect(result.tokenCount).toBeGreaterThan(0);
+      expect(mockTransactionCalled).toBe(true);
       expect(mockInsertCalled).toBe(true);
+      expect(mockOnConflictCalled).toBe(true);
     });
 
-    test('appends to existing conversation', async () => {
-      mockSelectRows = [
-        {
-          id: 'conv-1',
-          channelId: CHANNEL_ID,
-          externalThreadId: THREAD_ID,
-          messages: [{ role: 'user', content: 'Hello' }],
-          isCompacted: false,
-          summary: null,
-        },
-      ];
+    test('does NOT call select before inserting (no read-modify-write)', async () => {
+      mockSelectRows = [{ id: 'should-not-be-read' }];
       const msg: ConversationMessage = {
+        role: 'user',
+        content: 'Hello',
+        timestamp: '2026-01-01T00:00:00Z',
+      };
+      mockReturningRow = { messages: [msg] };
+      await memory.append(CHANNEL_ID, THREAD_ID, msg);
+      // Insert was the first DB action; no read-modify-write select happened
+      // before it (the prior implementation always selected first).
+      expect(mockInsertCalled).toBe(true);
+      expect(mockOnConflictCalled).toBe(true);
+    });
+
+    test('recomputes token count from the merged messages returned by ON CONFLICT', async () => {
+      const newMsg: ConversationMessage = {
         role: 'assistant',
         content: 'Hi there!',
         timestamp: '2026-01-01T00:00:01Z',
       };
-      const result = await memory.append(CHANNEL_ID, THREAD_ID, msg);
-      expect(result.tokenCount).toBeGreaterThan(0);
+      // Simulate the merged JSONB result returned by Postgres after the
+      // server-side concat: an existing message plus our new one.
+      mockReturningRow = {
+        messages: [{ role: 'user', content: 'Hello', timestamp: '2026-01-01T00:00:00Z' }, newMsg],
+      };
+      const result = await memory.append(CHANNEL_ID, THREAD_ID, newMsg);
+      // Token count should be > the count of just the new message alone
+      // because it's recomputed from the merged returned messages.
+      const newMsgOnlyTokenCount = Math.ceil(newMsg.content.length / 4);
+      expect(result.tokenCount).toBeGreaterThan(newMsgOnlyTokenCount);
       expect(mockUpdateCalled).toBe(true);
     });
 
     test('handles multiple messages in a single append', async () => {
-      mockSelectRows = [];
       const msgs: ConversationMessage[] = [
         { role: 'user', content: 'What is 2+2?', timestamp: '2026-01-01T00:00:00Z' },
         { role: 'assistant', content: 'It is 4.', timestamp: '2026-01-01T00:00:01Z' },
       ];
+      mockReturningRow = { messages: msgs };
       const result = await memory.append(CHANNEL_ID, THREAD_ID, ...msgs);
       expect(result.tokenCount).toBeGreaterThan(0);
     });

--- a/apps/api/src/memory/__tests__/engine.test.ts
+++ b/apps/api/src/memory/__tests__/engine.test.ts
@@ -18,13 +18,20 @@ function chainable(getRows: () => unknown[]): unknown {
   return Object.assign([...getRows()], methods);
 }
 
-mock.module('../../db', () => ({
-  getDb: () => ({
+function buildDbLike(): unknown {
+  return {
     select: () => chainable(() => mockSelectRows),
     insert: () => ({
       values: () => {
         mockInsertCalled = true;
-        return { returning: () => [] };
+        const obj: Record<string, unknown> = {
+          returning: () => [{ messages: [] }],
+          onConflictDoUpdate: () => {
+            return obj;
+          },
+          onConflictDoNothing: () => obj,
+        };
+        return obj;
       },
     }),
     update: () => ({
@@ -34,7 +41,12 @@ mock.module('../../db', () => ({
       },
     }),
     execute: async () => mockExecuteRows,
-  }),
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb(buildDbLike()),
+  };
+}
+
+mock.module('../../db', () => ({
+  getDb: () => buildDbLike(),
 }));
 
 mock.module('../../redis', () => ({

--- a/apps/api/src/memory/__tests__/engine.test.ts
+++ b/apps/api/src/memory/__tests__/engine.test.ts
@@ -25,7 +25,9 @@ function buildDbLike(): unknown {
       values: () => {
         mockInsertCalled = true;
         const obj: Record<string, unknown> = {
-          returning: () => [{ messages: [] }],
+          // xmax: '0' = fresh insert path (no conflict). MemoryEngine callers
+          // exercise ConversationMemory.append, which now branches on xmax.
+          returning: () => [{ messages: [], xmax: '0' }],
           onConflictDoUpdate: () => {
             return obj;
           },

--- a/apps/api/src/memory/conversation.ts
+++ b/apps/api/src/memory/conversation.ts
@@ -25,7 +25,7 @@ export class ConversationMemory {
       ];
     }
 
-    return (row.messages as ConversationMessage[]) ?? [];
+    return row.messages ?? [];
   }
 
   async append(
@@ -34,7 +34,6 @@ export class ConversationMemory {
     ...messages: ConversationMessage[]
   ): Promise<{ tokenCount: number }> {
     const db = getDb();
-    const newMessages = messages as unknown as Record<string, unknown>[];
     const initialText = messages.map((m) => m.content).join(' ');
     const initialTokenCount = estimateTokenCount(initialText);
 
@@ -42,13 +41,16 @@ export class ConversationMemory {
       // Atomic INSERT … ON CONFLICT DO UPDATE: when a row already exists for
       // (channel_id, external_thread_id), Postgres concatenates the existing
       // messages with the new ones in a single statement under a row-level
-      // lock, eliminating the read-modify-write race.
+      // lock, eliminating the read-modify-write race. `xmax` in RETURNING
+      // distinguishes the no-conflict insert path (xmax = '0') from the
+      // update path so we can skip the redundant token_count rewrite when
+      // the VALUES clause already wrote the correct count.
       const [row] = await tx
         .insert(conversations)
         .values({
           channelId,
           externalThreadId: threadId,
-          messages: newMessages,
+          messages,
           tokenCount: initialTokenCount,
         })
         .onConflictDoUpdate({
@@ -58,14 +60,23 @@ export class ConversationMemory {
             updatedAt: new Date(),
           },
         })
-        .returning({ messages: conversations.messages });
+        .returning({
+          messages: conversations.messages,
+          xmax: sql<string>`xmax::text`,
+        });
 
-      const mergedMessages = (row?.messages as ConversationMessage[] | undefined) ?? [];
+      const mergedMessages = row?.messages ?? [];
+      const isInsertPath = row?.xmax === '0';
+      if (isInsertPath) {
+        return { tokenCount: initialTokenCount };
+      }
+
       const allText = mergedMessages.map((m) => m.content).join(' ');
       const tokenCount = estimateTokenCount(allText);
 
-      // Recompute token_count from the merged messages so concurrent appends
-      // don't leave it referring to only one writer's contribution.
+      // Conflict path: recompute token_count from the merged messages so
+      // concurrent appends don't leave it referring to only one writer's
+      // contribution.
       await tx
         .update(conversations)
         .set({ tokenCount })

--- a/apps/api/src/memory/conversation.ts
+++ b/apps/api/src/memory/conversation.ts
@@ -34,43 +34,47 @@ export class ConversationMemory {
     ...messages: ConversationMessage[]
   ): Promise<{ tokenCount: number }> {
     const db = getDb();
+    const newMessages = messages as unknown as Record<string, unknown>[];
+    const initialText = messages.map((m) => m.content).join(' ');
+    const initialTokenCount = estimateTokenCount(initialText);
 
-    const [existing] = await db
-      .select()
-      .from(conversations)
-      .where(
-        and(eq(conversations.channelId, channelId), eq(conversations.externalThreadId, threadId)),
-      );
+    return await db.transaction(async (tx) => {
+      // Atomic INSERT … ON CONFLICT DO UPDATE: when a row already exists for
+      // (channel_id, external_thread_id), Postgres concatenates the existing
+      // messages with the new ones in a single statement under a row-level
+      // lock, eliminating the read-modify-write race.
+      const [row] = await tx
+        .insert(conversations)
+        .values({
+          channelId,
+          externalThreadId: threadId,
+          messages: newMessages,
+          tokenCount: initialTokenCount,
+        })
+        .onConflictDoUpdate({
+          target: [conversations.channelId, conversations.externalThreadId],
+          set: {
+            messages: sql`${conversations.messages} || EXCLUDED.messages`,
+            updatedAt: new Date(),
+          },
+        })
+        .returning({ messages: conversations.messages });
 
-    if (existing) {
-      const currentMessages = (existing.messages as ConversationMessage[]) ?? [];
-      const updatedMessages = [...currentMessages, ...messages];
-      const allText = updatedMessages.map((m) => m.content).join(' ');
+      const mergedMessages = (row?.messages as ConversationMessage[] | undefined) ?? [];
+      const allText = mergedMessages.map((m) => m.content).join(' ');
       const tokenCount = estimateTokenCount(allText);
 
-      await db
+      // Recompute token_count from the merged messages so concurrent appends
+      // don't leave it referring to only one writer's contribution.
+      await tx
         .update(conversations)
-        .set({
-          messages: updatedMessages as unknown as Record<string, unknown>[],
-          tokenCount,
-          updatedAt: new Date(),
-        })
-        .where(eq(conversations.id, existing.id));
+        .set({ tokenCount })
+        .where(
+          and(eq(conversations.channelId, channelId), eq(conversations.externalThreadId, threadId)),
+        );
 
       return { tokenCount };
-    }
-
-    const allText = messages.map((m) => m.content).join(' ');
-    const tokenCount = estimateTokenCount(allText);
-
-    await db.insert(conversations).values({
-      channelId,
-      externalThreadId: threadId,
-      messages: messages as unknown as Record<string, unknown>[],
-      tokenCount,
     });
-
-    return { tokenCount };
   }
 
   async compact(channelId: string, threadId: string, summary: string): Promise<void> {

--- a/apps/api/src/middleware/__tests__/rate-limiter.test.ts
+++ b/apps/api/src/middleware/__tests__/rate-limiter.test.ts
@@ -1,18 +1,18 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 let mockRedisAvailable = false;
-let mockIncrValue = 0;
-let mockTtlValue = 50;
+let mockEvalReturn: [number, number] = [0, 60];
+let mockEvalThrows = false;
+let mockEvalCalls = 0;
 
 mock.module('../../redis', () => ({
   isRedisAvailable: () => mockRedisAvailable,
   getRedis: () => ({
-    incr: async () => {
-      mockIncrValue++;
-      return mockIncrValue;
+    eval: async () => {
+      mockEvalCalls++;
+      if (mockEvalThrows) throw new Error('redis eval failed');
+      return mockEvalReturn;
     },
-    expire: async () => {},
-    ttl: async () => mockTtlValue,
   }),
 }));
 
@@ -24,14 +24,16 @@ describe('checkRateLimit', () => {
 
   beforeEach(() => {
     mockRedisAvailable = false;
-    mockIncrValue = 0;
-    mockTtlValue = 50;
+    mockEvalReturn = [0, 60];
+    mockEvalThrows = false;
+    mockEvalCalls = 0;
   });
 
   afterEach(() => {
     mockRedisAvailable = false;
-    mockIncrValue = 0;
-    mockTtlValue = 50;
+    mockEvalReturn = [0, 60];
+    mockEvalThrows = false;
+    mockEvalCalls = 0;
   });
 
   test('allows request when Redis is unavailable', async () => {
@@ -40,20 +42,24 @@ describe('checkRateLimit', () => {
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(30);
     expect(result.retryAfterSeconds).toBe(0);
+    // Script must not run when Redis is unavailable.
+    expect(mockEvalCalls).toBe(0);
   });
 
   test('allows request within rate limit', async () => {
     mockRedisAvailable = true;
-    mockIncrValue = 0;
+    mockEvalReturn = [1, 60];
     const result = await checkRateLimit(CHANNEL_ID, USER_ID, 10);
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(9);
     expect(result.retryAfterSeconds).toBe(0);
+    // One round-trip per check.
+    expect(mockEvalCalls).toBe(1);
   });
 
   test('denies request exceeding rate limit', async () => {
     mockRedisAvailable = true;
-    mockIncrValue = 30;
+    mockEvalReturn = [31, 30];
     const result = await checkRateLimit(CHANNEL_ID, USER_ID, 30);
     expect(result.allowed).toBe(false);
     expect(result.remaining).toBe(0);
@@ -62,24 +68,52 @@ describe('checkRateLimit', () => {
 
   test('uses default limit of 30 per minute', async () => {
     mockRedisAvailable = true;
-    mockIncrValue = 0;
+    mockEvalReturn = [1, 60];
     const result = await checkRateLimit(CHANNEL_ID, USER_ID);
     expect(result.remaining).toBe(29);
   });
 
   test('uses custom limit', async () => {
     mockRedisAvailable = true;
-    mockIncrValue = 0;
+    mockEvalReturn = [1, 60];
     const result = await checkRateLimit(CHANNEL_ID, USER_ID, 5);
     expect(result.remaining).toBe(4);
   });
 
-  test('returns retryAfterSeconds from TTL when denied', async () => {
+  test('returns retryAfterSeconds from script TTL when denied', async () => {
     mockRedisAvailable = true;
-    mockIncrValue = 99;
-    mockTtlValue = 42;
+    mockEvalReturn = [99, 42];
     const result = await checkRateLimit(CHANNEL_ID, USER_ID, 10);
     expect(result.allowed).toBe(false);
     expect(result.retryAfterSeconds).toBe(42);
+  });
+
+  test('first hit (count=1) carries the freshly applied TTL', async () => {
+    mockRedisAvailable = true;
+    // Script returns [current=1, ttl=window] when it just applied EXPIRE.
+    mockEvalReturn = [1, 60];
+    const result = await checkRateLimit(CHANNEL_ID, USER_ID, 10);
+    expect(result.allowed).toBe(true);
+    // Allowed → retryAfterSeconds is 0 by contract; the TTL is observable
+    // via a denied response, exercised in the previous test.
+    expect(result.retryAfterSeconds).toBe(0);
+  });
+
+  test('falls back to allow when redis.eval throws', async () => {
+    mockRedisAvailable = true;
+    mockEvalThrows = true;
+    const result = await checkRateLimit(CHANNEL_ID, USER_ID, 5);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(5);
+    expect(result.retryAfterSeconds).toBe(0);
+  });
+
+  test('handles string-typed numbers from redis.eval (defensive)', async () => {
+    mockRedisAvailable = true;
+    // Some Redis client serializers stringify Lua numbers — verify we coerce.
+    mockEvalReturn = ['1' as unknown as number, '60' as unknown as number];
+    const result = await checkRateLimit(CHANNEL_ID, USER_ID, 10);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(9);
   });
 });

--- a/apps/api/src/middleware/__tests__/rate-limiter.test.ts
+++ b/apps/api/src/middleware/__tests__/rate-limiter.test.ts
@@ -8,7 +8,10 @@ let mockEvalCalls = 0;
 mock.module('../../redis', () => ({
   isRedisAvailable: () => mockRedisAvailable,
   getRedis: () => ({
-    eval: async () => {
+    // Custom command registered via defineCommand in redis.ts — the
+    // production call site uses redis.rateLimitIncr(key, ttl), and the
+    // mock mirrors that surface so we exercise the real path.
+    rateLimitIncr: async () => {
       mockEvalCalls++;
       if (mockEvalThrows) throw new Error('redis eval failed');
       return mockEvalReturn;
@@ -115,5 +118,18 @@ describe('checkRateLimit', () => {
     const result = await checkRateLimit(CHANNEL_ID, USER_ID, 10);
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(9);
+  });
+
+  test('coerces non-numeric Redis returns to 0 instead of NaN', async () => {
+    mockRedisAvailable = true;
+    // Defensive: a misbehaving Redis (or buffer-mode response) could surface
+    // an empty string or garbage where we expect a number. `remaining` and
+    // TTL math must stay finite.
+    mockEvalReturn = ['' as unknown as number, 'abc' as unknown as number];
+    const result = await checkRateLimit(CHANNEL_ID, USER_ID, 10);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(10);
+    expect(Number.isFinite(result.remaining)).toBe(true);
+    expect(Number.isFinite(result.retryAfterSeconds)).toBe(true);
   });
 });

--- a/apps/api/src/middleware/rate-limiter.ts
+++ b/apps/api/src/middleware/rate-limiter.ts
@@ -13,6 +13,32 @@ export interface RateLimitResult {
   retryAfterSeconds: number;
 }
 
+// Atomic INCR-and-EXPIRE in a single Redis round-trip. Using a Lua script
+// avoids the immortal-key bug where a process crash between separate INCR
+// and EXPIRE calls leaves a counter with no TTL, permanently rate-limiting
+// the user. The script also re-applies the TTL if a previous run left the
+// key without one (PTTL/TTL returns -1) so legacy keys self-heal.
+const RATE_LIMIT_SCRIPT = `
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+  return {current, tonumber(ARGV[1])}
+end
+local ttl = redis.call('TTL', KEYS[1])
+if ttl < 0 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+  ttl = tonumber(ARGV[1])
+end
+return {current, ttl}
+`;
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') return Number(value);
+  if (typeof value === 'bigint') return Number(value);
+  return 0;
+}
+
 export async function checkRateLimit(
   channelId: string,
   userId: string,
@@ -26,13 +52,15 @@ export async function checkRateLimit(
 
   try {
     const redis = getRedis();
-    const current = await redis.incr(key);
+    const result = (await redis.eval(
+      RATE_LIMIT_SCRIPT,
+      1,
+      key,
+      String(VALKEY_TTL.rateLimitWindow),
+    )) as [unknown, unknown];
 
-    if (current === 1) {
-      await redis.expire(key, VALKEY_TTL.rateLimitWindow);
-    }
-
-    const ttl = await redis.ttl(key);
+    const current = toNumber(result?.[0]);
+    const ttl = toNumber(result?.[1]);
     const retryAfter = ttl > 0 ? ttl : VALKEY_TTL.rateLimitWindow;
 
     if (current > limitPerMinute) {

--- a/apps/api/src/middleware/rate-limiter.ts
+++ b/apps/api/src/middleware/rate-limiter.ts
@@ -13,28 +13,15 @@ export interface RateLimitResult {
   retryAfterSeconds: number;
 }
 
-// Atomic INCR-and-EXPIRE in a single Redis round-trip. Using a Lua script
-// avoids the immortal-key bug where a process crash between separate INCR
-// and EXPIRE calls leaves a counter with no TTL, permanently rate-limiting
-// the user. The script also re-applies the TTL if a previous run left the
-// key without one (PTTL/TTL returns -1) so legacy keys self-heal.
-const RATE_LIMIT_SCRIPT = `
-local current = redis.call('INCR', KEYS[1])
-if current == 1 then
-  redis.call('EXPIRE', KEYS[1], ARGV[1])
-  return {current, tonumber(ARGV[1])}
-end
-local ttl = redis.call('TTL', KEYS[1])
-if ttl < 0 then
-  redis.call('EXPIRE', KEYS[1], ARGV[1])
-  ttl = tonumber(ARGV[1])
-end
-return {current, ttl}
-`;
-
+// Coerce Redis return values (numbers, bulk strings, bigints) to a finite
+// JS number; anything unparseable falls back to 0 so `remaining` and TTL
+// math never produce NaN.
 function toNumber(value: unknown): number {
-  if (typeof value === 'number') return value;
-  if (typeof value === 'string') return Number(value);
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+  if (typeof value === 'string') {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  }
   if (typeof value === 'bigint') return Number(value);
   return 0;
 }
@@ -52,12 +39,15 @@ export async function checkRateLimit(
 
   try {
     const redis = getRedis();
-    const result = (await redis.eval(
-      RATE_LIMIT_SCRIPT,
-      1,
-      key,
-      String(VALKEY_TTL.rateLimitWindow),
-    )) as [unknown, unknown];
+    // Custom command registered in `redis.ts` via `defineCommand` — first
+    // call ships the Lua body, subsequent calls go over EVALSHA. Atomic
+    // INCR + EXPIRE eliminates the immortal-key bug where a crash between
+    // separate INCR/EXPIRE calls leaves a counter with no TTL; the script
+    // also re-applies the TTL if a key has none, self-healing legacy keys.
+    const result = (await redis.rateLimitIncr(key, String(VALKEY_TTL.rateLimitWindow))) as [
+      unknown,
+      unknown,
+    ];
 
     const current = toNumber(result?.[0]);
     const ttl = toNumber(result?.[1]);

--- a/apps/api/src/redis.ts
+++ b/apps/api/src/redis.ts
@@ -5,11 +5,32 @@ import { errorDetails } from './utils/error-fmt';
 
 const logger = getLogger(['personalclaw', 'valkey']);
 
-let redisInstance: Redis | null = null;
+// Atomic INCR-and-EXPIRE in a single Redis round-trip. Registered once per
+// connection via defineCommand so subsequent calls go over EVALSHA, avoiding
+// re-shipping the Lua body on every rate-limit check.
+const RATE_LIMIT_SCRIPT = `
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+  return {current, tonumber(ARGV[1])}
+end
+local ttl = redis.call('TTL', KEYS[1])
+if ttl < 0 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+  ttl = tonumber(ARGV[1])
+end
+return {current, ttl}
+`;
 
-export function getRedis(): Redis {
+export interface RateLimitRedis extends Redis {
+  rateLimitIncr(key: string, ttl: string): Promise<[number, number]>;
+}
+
+let redisInstance: RateLimitRedis | null = null;
+
+export function getRedis(): RateLimitRedis {
   if (!redisInstance) {
-    redisInstance = new Redis(redisUrl(), {
+    const r = new Redis(redisUrl(), {
       maxRetriesPerRequest: 3,
       retryStrategy(times) {
         if (times > 5) return null;
@@ -18,13 +39,17 @@ export function getRedis(): Redis {
       lazyConnect: true,
     });
 
-    redisInstance.on('error', (err) => {
+    r.defineCommand('rateLimitIncr', { numberOfKeys: 1, lua: RATE_LIMIT_SCRIPT });
+
+    r.on('error', (err) => {
       logger.error('Valkey connection error', errorDetails(err));
     });
 
-    redisInstance.connect().catch((err) => {
+    r.connect().catch((err) => {
       logger.warn('Valkey initial connection failed, will retry', errorDetails(err));
     });
+
+    redisInstance = r as RateLimitRedis;
   }
   return redisInstance;
 }

--- a/apps/api/src/services/__tests__/mcp.service.test.ts
+++ b/apps/api/src/services/__tests__/mcp.service.test.ts
@@ -33,6 +33,9 @@ let mockSelectRows: unknown[] = [];
 let mockInsertRows: unknown[] = [];
 let mockUpdateRows: unknown[] = [];
 let mockDeleteRows: unknown[] = [];
+let mockSelectCalled = false;
+let lastInsertValues: Record<string, unknown> | null = null;
+let lastConflictUpdateSet: Record<string, unknown> | null = null;
 
 function chainable(getRows: () => unknown[]): unknown {
   const methods: Record<string, unknown> = {};
@@ -46,16 +49,25 @@ function insertChain(getRows: () => unknown[]): unknown {
   const obj: Record<string, unknown> = {
     returning: () => [...getRows()],
   };
-  obj.onConflictDoUpdate = () => obj;
+  obj.onConflictDoUpdate = (arg: { set?: Record<string, unknown> }) => {
+    lastConflictUpdateSet = arg?.set ?? null;
+    return obj;
+  };
   obj.onConflictDoNothing = () => obj;
   return obj;
 }
 
 mock.module('../../db', () => ({
   getDb: () => ({
-    select: () => chainable(() => mockSelectRows),
+    select: () => {
+      mockSelectCalled = true;
+      return chainable(() => mockSelectRows);
+    },
     insert: () => ({
-      values: () => insertChain(() => mockInsertRows),
+      values: (vals: Record<string, unknown>) => {
+        lastInsertValues = vals;
+        return insertChain(() => mockInsertRows);
+      },
     }),
     update: () => ({
       set: () => chainable(() => mockUpdateRows),
@@ -83,6 +95,9 @@ describe('MCPService', () => {
     mockInsertRows = [];
     mockUpdateRows = [];
     mockDeleteRows = [];
+    mockSelectCalled = false;
+    lastInsertValues = null;
+    lastConflictUpdateSet = null;
   });
 
   afterEach(() => {
@@ -90,6 +105,9 @@ describe('MCPService', () => {
     mockInsertRows = [];
     mockUpdateRows = [];
     mockDeleteRows = [];
+    mockSelectCalled = false;
+    lastInsertValues = null;
+    lastConflictUpdateSet = null;
   });
 
   describe('listGlobal', () => {
@@ -180,10 +198,17 @@ describe('MCPService', () => {
   describe('upsertToolPolicy', () => {
     test('creates new policy via INSERT ON CONFLICT (channel-scoped)', async () => {
       mockSelectRows = [];
-      mockInsertRows = [MOCK_TOOL_POLICY];
+      // Mock returns a row that mirrors the input so the assertion would fail
+      // if the implementation dropped `disabledTools` on the floor. Both the
+      // INSERT values and the ON CONFLICT update set are checked below.
+      mockInsertRows = [{ ...MOCK_TOOL_POLICY, denyList: ['tool_a'] }];
       const result = await service.upsertToolPolicy('mcp-001', CHANNEL_ID, ['tool_a']);
       expect(result).toBeDefined();
-      expect(result?.denyList).toEqual(['dangerous_tool']);
+      expect(result?.denyList).toEqual(['tool_a']);
+      expect(lastInsertValues?.denyList).toEqual(['tool_a']);
+      expect(lastInsertValues?.channelId).toBe(CHANNEL_ID);
+      expect(lastInsertValues?.mcpConfigId).toBe('mcp-001');
+      expect(lastConflictUpdateSet?.denyList).toEqual(['tool_a']);
     });
 
     test('updates existing policy via INSERT ON CONFLICT (channel-scoped)', async () => {
@@ -192,6 +217,8 @@ describe('MCPService', () => {
       const result = await service.upsertToolPolicy('mcp-001', CHANNEL_ID, ['tool_b']);
       expect(result).toBeDefined();
       expect(result?.denyList).toEqual(['tool_b']);
+      expect(lastInsertValues?.denyList).toEqual(['tool_b']);
+      expect(lastConflictUpdateSet?.denyList).toEqual(['tool_b']);
     });
 
     test('upserts global policy via INSERT ON CONFLICT (channelId null)', async () => {
@@ -201,13 +228,18 @@ describe('MCPService', () => {
       expect(result).toBeDefined();
       expect(result?.channelId).toBeNull();
       expect(result?.denyList).toEqual(['tool_c']);
+      expect(lastInsertValues?.channelId).toBeNull();
+      expect(lastInsertValues?.denyList).toEqual(['tool_c']);
     });
 
     test('does not call select before upsert (atomic path)', async () => {
       mockSelectRows = [{ id: 'should-not-be-read' }];
-      mockInsertRows = [MOCK_TOOL_POLICY];
+      mockInsertRows = [{ ...MOCK_TOOL_POLICY, denyList: ['tool_a'] }];
       const result = await service.upsertToolPolicy('mcp-001', CHANNEL_ID, ['tool_a']);
       expect(result).toBeDefined();
+      // Guards against regressing back to the check-then-act read-modify-write
+      // pattern: the atomic INSERT … ON CONFLICT path must not select first.
+      expect(mockSelectCalled).toBe(false);
     });
   });
 

--- a/apps/api/src/services/__tests__/mcp.service.test.ts
+++ b/apps/api/src/services/__tests__/mcp.service.test.ts
@@ -42,13 +42,20 @@ function chainable(getRows: () => unknown[]): unknown {
   return Object.assign([...getRows()], methods);
 }
 
+function insertChain(getRows: () => unknown[]): unknown {
+  const obj: Record<string, unknown> = {
+    returning: () => [...getRows()],
+  };
+  obj.onConflictDoUpdate = () => obj;
+  obj.onConflictDoNothing = () => obj;
+  return obj;
+}
+
 mock.module('../../db', () => ({
   getDb: () => ({
     select: () => chainable(() => mockSelectRows),
     insert: () => ({
-      values: () => ({
-        returning: () => [...mockInsertRows],
-      }),
+      values: () => insertChain(() => mockInsertRows),
     }),
     update: () => ({
       set: () => chainable(() => mockUpdateRows),
@@ -171,17 +178,35 @@ describe('MCPService', () => {
   });
 
   describe('upsertToolPolicy', () => {
-    test('creates new policy when none exists', async () => {
+    test('creates new policy via INSERT ON CONFLICT (channel-scoped)', async () => {
       mockSelectRows = [];
       mockInsertRows = [MOCK_TOOL_POLICY];
       const result = await service.upsertToolPolicy('mcp-001', CHANNEL_ID, ['tool_a']);
       expect(result).toBeDefined();
+      expect(result?.denyList).toEqual(['dangerous_tool']);
     });
 
-    test('updates existing policy', async () => {
-      mockSelectRows = [MOCK_TOOL_POLICY];
-      mockUpdateRows = [{ ...MOCK_TOOL_POLICY, denyList: ['tool_b'] }];
+    test('updates existing policy via INSERT ON CONFLICT (channel-scoped)', async () => {
+      mockSelectRows = [];
+      mockInsertRows = [{ ...MOCK_TOOL_POLICY, denyList: ['tool_b'] }];
       const result = await service.upsertToolPolicy('mcp-001', CHANNEL_ID, ['tool_b']);
+      expect(result).toBeDefined();
+      expect(result?.denyList).toEqual(['tool_b']);
+    });
+
+    test('upserts global policy via INSERT ON CONFLICT (channelId null)', async () => {
+      mockSelectRows = [];
+      mockInsertRows = [{ ...MOCK_TOOL_POLICY, channelId: null, denyList: ['tool_c'] }];
+      const result = await service.upsertToolPolicy('mcp-001', null, ['tool_c']);
+      expect(result).toBeDefined();
+      expect(result?.channelId).toBeNull();
+      expect(result?.denyList).toEqual(['tool_c']);
+    });
+
+    test('does not call select before upsert (atomic path)', async () => {
+      mockSelectRows = [{ id: 'should-not-be-read' }];
+      mockInsertRows = [MOCK_TOOL_POLICY];
+      const result = await service.upsertToolPolicy('mcp-001', CHANNEL_ID, ['tool_a']);
       expect(result).toBeDefined();
     });
   });

--- a/apps/api/src/services/mcp.service.ts
+++ b/apps/api/src/services/mcp.service.ts
@@ -1,5 +1,5 @@
 import { createMCPClient } from '@ai-sdk/mcp';
-import { and, eq, isNull, mcpConfigs, or, toolPolicies } from '@personalclaw/db';
+import { and, eq, isNull, mcpConfigs, or, sql, toolPolicies } from '@personalclaw/db';
 import type { CreateMCPConfigInput, MCPTransportType } from '@personalclaw/shared';
 import {
   stdioArgsSchema,
@@ -170,32 +170,27 @@ export class MCPService {
 
   async upsertToolPolicy(mcpConfigId: string, channelId: string | null, disabledTools: string[]) {
     const db = getDb();
-    const channelCondition = channelId
-      ? eq(toolPolicies.channelId, channelId)
-      : isNull(toolPolicies.channelId);
 
-    const [existing] = await db
-      .select()
-      .from(toolPolicies)
-      .where(and(eq(toolPolicies.mcpConfigId, mcpConfigId), channelCondition))
-      .limit(1);
-
-    if (existing) {
+    if (channelId === null) {
       const [row] = await db
-        .update(toolPolicies)
-        .set({ denyList: disabledTools, allowList: [] })
-        .where(eq(toolPolicies.id, existing.id))
+        .insert(toolPolicies)
+        .values({ mcpConfigId, channelId: null, denyList: disabledTools, allowList: [] })
+        .onConflictDoUpdate({
+          target: toolPolicies.mcpConfigId,
+          targetWhere: sql`${toolPolicies.channelId} IS NULL`,
+          set: { denyList: disabledTools, allowList: [] },
+        })
         .returning();
       return row;
     }
 
     const [row] = await db
       .insert(toolPolicies)
-      .values({
-        mcpConfigId,
-        channelId,
-        denyList: disabledTools,
-        allowList: [],
+      .values({ mcpConfigId, channelId, denyList: disabledTools, allowList: [] })
+      .onConflictDoUpdate({
+        target: [toolPolicies.mcpConfigId, toolPolicies.channelId],
+        targetWhere: sql`${toolPolicies.channelId} IS NOT NULL`,
+        set: { denyList: disabledTools, allowList: [] },
       })
       .returning();
     return row;

--- a/packages/db/src/migrations/0016_tool_policy_unique.sql
+++ b/packages/db/src/migrations/0016_tool_policy_unique.sql
@@ -1,0 +1,27 @@
+-- Deduplicate any existing duplicate rows on (mcp_config_id, channel_id),
+-- keeping the most recently created row per group. Postgres groups NULLs
+-- together inside PARTITION BY, so this also dedupes global (channel_id IS
+-- NULL) duplicates.
+WITH ranked AS (
+  SELECT id,
+    ROW_NUMBER() OVER (
+      PARTITION BY "mcp_config_id", "channel_id"
+      ORDER BY "created_at" DESC, "id" DESC
+    ) AS rn
+  FROM "tool_policies"
+)
+DELETE FROM "tool_policies"
+WHERE "id" IN (SELECT "id" FROM ranked WHERE rn > 1);
+--> statement-breakpoint
+-- Partial unique index for channel-scoped policies (channel_id NOT NULL).
+-- Standard unique constraints can't span a nullable column safely because
+-- Postgres treats NULLs as distinct in unique comparisons.
+CREATE UNIQUE INDEX IF NOT EXISTS "tool_policies_mcp_channel_unique"
+  ON "tool_policies" ("mcp_config_id", "channel_id")
+  WHERE "channel_id" IS NOT NULL;
+--> statement-breakpoint
+-- Partial unique index for global policies (channel_id IS NULL): one global
+-- policy row per mcp_config_id.
+CREATE UNIQUE INDEX IF NOT EXISTS "tool_policies_mcp_channel_null_unique"
+  ON "tool_policies" ("mcp_config_id")
+  WHERE "channel_id" IS NULL;

--- a/packages/db/src/migrations/0017_conversations_unique_thread.sql
+++ b/packages/db/src/migrations/0017_conversations_unique_thread.sql
@@ -1,0 +1,22 @@
+-- Deduplicate any existing duplicate rows on (channel_id, external_thread_id),
+-- keeping the most recently updated row per group.
+WITH ranked AS (
+  SELECT id,
+    ROW_NUMBER() OVER (
+      PARTITION BY "channel_id", "external_thread_id"
+      ORDER BY "updated_at" DESC, "id" DESC
+    ) AS rn
+  FROM "conversations"
+)
+DELETE FROM "conversations"
+WHERE "id" IN (SELECT "id" FROM ranked WHERE rn > 1);
+--> statement-breakpoint
+-- Replace the existing non-unique index with a unique constraint. Both
+-- columns are NOT NULL, so a standard unique constraint is sufficient. The
+-- unique constraint creates its own backing btree index, making the prior
+-- non-unique one redundant.
+DROP INDEX IF EXISTS "conversations_channel_thread_idx";
+--> statement-breakpoint
+ALTER TABLE "conversations"
+  ADD CONSTRAINT "conversations_channel_thread_unique"
+  UNIQUE ("channel_id", "external_thread_id");

--- a/packages/db/src/migrations/0017_conversations_unique_thread.sql
+++ b/packages/db/src/migrations/0017_conversations_unique_thread.sql
@@ -17,6 +17,14 @@ WHERE "id" IN (SELECT "id" FROM ranked WHERE rn > 1);
 -- non-unique one redundant.
 DROP INDEX IF EXISTS "conversations_channel_thread_idx";
 --> statement-breakpoint
-ALTER TABLE "conversations"
-  ADD CONSTRAINT "conversations_channel_thread_unique"
-  UNIQUE ("channel_id", "external_thread_id");
+-- Postgres has no `ADD CONSTRAINT IF NOT EXISTS`, so wrap in a DO block that
+-- swallows the duplicate_object error to keep this migration idempotent
+-- alongside the `IF NOT EXISTS` guards used elsewhere (e.g. migration 0016).
+DO $$ BEGIN
+  ALTER TABLE "conversations"
+    ADD CONSTRAINT "conversations_channel_thread_unique"
+    UNIQUE ("channel_id", "external_thread_id");
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+  WHEN duplicate_table THEN NULL;
+END $$;

--- a/packages/db/src/migrations/meta/0017_snapshot.json
+++ b/packages/db/src/migrations/meta/0017_snapshot.json
@@ -1,0 +1,1785 @@
+{
+  "id": "4c95db39-1473-4ebe-a83a-655f2ea1b597",
+  "prevId": "5847d9b1-85e9-4233-9610-1a0a54df7ece",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.approval_policies": {
+      "name": "approval_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ask'"
+        },
+        "allowed_users": {
+          "name": "allowed_users",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "approval_policies_channel_id_channels_id_fk": {
+          "name": "approval_policies_channel_id_channels_id_fk",
+          "tableFrom": "approval_policies",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approval_policies_channel_tool_unique": {
+          "name": "approval_policies_channel_tool_unique",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id", "tool_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_memories": {
+      "name": "channel_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fact'"
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recall_count": {
+          "name": "recall_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_recalled_at": {
+          "name": "last_recalled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_memories_channel_idx": {
+          "name": "channel_memories_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_memories_channel_id_channels_id_fk": {
+          "name": "channel_memories_channel_id_channels_id_fk",
+          "tableFrom": "channel_memories",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channels": {
+      "name": "channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'slack'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_name": {
+          "name": "external_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_prompt": {
+          "name": "identity_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_prompt": {
+          "name": "team_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-sonnet-4-20250514'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'anthropic'"
+        },
+        "max_iterations": {
+          "name": "max_iterations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "guardrails_config": {
+          "name": "guardrails_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_enabled": {
+          "name": "sandbox_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sandbox_config": {
+          "name": "sandbox_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_enabled": {
+          "name": "heartbeat_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "heartbeat_prompt": {
+          "name": "heartbeat_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_cron": {
+          "name": "heartbeat_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'*/30 * * * *'"
+        },
+        "memory_config": {
+          "name": "memory_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"maxMemories\":200,\"injectTopN\":10}'::jsonb"
+        },
+        "prompt_inject_mode": {
+          "name": "prompt_inject_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'every-turn'"
+        },
+        "provider_fallback": {
+          "name": "provider_fallback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[{\"provider\":\"anthropic\",\"model\":\"claude-sonnet-4-20250514\"}]'::jsonb"
+        },
+        "browser_enabled": {
+          "name": "browser_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cost_budget_daily_usd": {
+          "name": "cost_budget_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_reply_mode": {
+          "name": "thread_reply_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "autonomy_level": {
+          "name": "autonomy_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'balanced'"
+        },
+        "approval_timeout_ms": {
+          "name": "approval_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 600000
+        },
+        "channel_admins": {
+          "name": "channel_admins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "channels_platform_external_id_idx": {
+          "name": "channels_platform_external_id_idx",
+          "nullsNotDistinct": false,
+          "columns": ["platform", "external_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_thread_id": {
+          "name": "external_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_compacted": {
+          "name": "is_compacted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_channel_id_channels_id_fk": {
+          "name": "conversations_channel_id_channels_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_channel_thread_unique": {
+          "name": "conversations_channel_thread_unique",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id", "external_thread_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.detection_audit_annotations": {
+      "name": "detection_audit_annotations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotation_kind": {
+          "name": "annotation_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotated_by": {
+          "name": "annotated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "detection_audit_annotations_channel_created_idx": {
+          "name": "detection_audit_annotations_channel_created_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "detection_audit_annotations_event_idx": {
+          "name": "detection_audit_annotations_event_idx",
+          "columns": [
+            {
+              "expression": "audit_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "detection_audit_annotations_audit_event_id_detection_audit_events_id_fk": {
+          "name": "detection_audit_annotations_audit_event_id_detection_audit_events_id_fk",
+          "tableFrom": "detection_audit_annotations",
+          "tableTo": "detection_audit_events",
+          "columnsFrom": ["audit_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "detection_audit_annotations_channel_id_channels_id_fk": {
+          "name": "detection_audit_annotations_channel_id_channels_id_fk",
+          "tableFrom": "detection_audit_annotations",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "detection_audit_annotations_event_annotator_unique": {
+          "name": "detection_audit_annotations_event_annotator_unique",
+          "nullsNotDistinct": false,
+          "columns": ["audit_event_id", "annotated_by"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.detection_audit_events": {
+      "name": "detection_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layers_fired": {
+          "name": "layers_fired",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redacted_excerpt": {
+          "name": "redacted_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canary_hit": {
+          "name": "canary_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "detection_audit_events_channel_created_idx": {
+          "name": "detection_audit_events_channel_created_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "detection_audit_events_decision_created_idx": {
+          "name": "detection_audit_events_decision_created_idx",
+          "columns": [
+            {
+              "expression": "decision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "detection_audit_events_channel_id_channels_id_fk": {
+          "name": "detection_audit_events_channel_id_channels_id_fk",
+          "tableFrom": "detection_audit_events",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "detection_audit_events_reference_id_unique": {
+          "name": "detection_audit_events_reference_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["reference_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.detection_corpus_embeddings": {
+      "name": "detection_corpus_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "signature_id": {
+          "name": "signature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_text": {
+          "name": "signature_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_category": {
+          "name": "signature_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_provider": {
+          "name": "embedding_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "detection_corpus_embeddings_signature_idx": {
+          "name": "detection_corpus_embeddings_signature_idx",
+          "columns": [
+            {
+              "expression": "signature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "detection_corpus_embeddings_sig_provider_version_unique": {
+          "name": "detection_corpus_embeddings_sig_provider_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["signature_id", "embedding_provider", "source_version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.detection_overrides": {
+      "name": "detection_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_kind": {
+          "name": "override_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "detection_overrides_channel_idx": {
+          "name": "detection_overrides_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "detection_overrides_channel_id_channels_id_fk": {
+          "name": "detection_overrides_channel_id_channels_id_fk",
+          "tableFrom": "detection_overrides",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "detection_overrides_channel_kind_key_unique": {
+          "name": "detection_overrides_channel_kind_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id", "override_kind", "target_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_configs": {
+      "name": "mcp_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport_type": {
+          "name": "transport_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sse'"
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_configs_channel_id_channels_id_fk": {
+          "name": "mcp_configs_channel_id_channels_id_fk",
+          "tableFrom": "mcp_configs",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_configs_channel_server_unique": {
+          "name": "mcp_configs_channel_server_unique",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id", "server_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_users": {
+          "name": "notify_users",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedules_channel_id_channels_id_fk": {
+          "name": "schedules_channel_id_channels_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_usages": {
+      "name": "skill_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "was_helpful": {
+          "name": "was_helpful",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_usages_skill_idx": {
+          "name": "skill_usages_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_usages_channel_idx": {
+          "name": "skill_usages_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_usages_skill_id_skills_id_fk": {
+          "name": "skill_usages_skill_id_skills_id_fk",
+          "tableFrom": "skill_usages",
+          "tableTo": "skills",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_usages_channel_id_channels_id_fk": {
+          "name": "skill_usages_channel_id_channels_id_fk",
+          "tableFrom": "skill_usages",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skills_channel_id_channels_id_fk": {
+          "name": "skills_channel_id_channels_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_policies": {
+      "name": "tool_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_config_id": {
+          "name": "mcp_config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_list": {
+          "name": "allow_list",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "deny_list": {
+          "name": "deny_list",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tool_policies_mcp_channel_unique": {
+          "name": "tool_policies_mcp_channel_unique",
+          "columns": [
+            {
+              "expression": "mcp_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tool_policies\".\"channel_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tool_policies_mcp_channel_null_unique": {
+          "name": "tool_policies_mcp_channel_null_unique",
+          "columns": [
+            {
+              "expression": "mcp_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tool_policies\".\"channel_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tool_policies_channel_id_channels_id_fk": {
+          "name": "tool_policies_channel_id_channels_id_fk",
+          "tableFrom": "tool_policies",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tool_policies_mcp_config_id_mcp_configs_id_fk": {
+          "name": "tool_policies_mcp_config_id_mcp_configs_id_fk",
+          "tableFrom": "tool_policies",
+          "tableTo": "mcp_configs",
+          "columnsFrom": ["mcp_config_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_logs": {
+      "name": "usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_thread_id": {
+          "name": "external_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_logs_channel_created_idx": {
+          "name": "usage_logs_channel_created_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_logs_user_created_idx": {
+          "name": "usage_logs_user_created_idx",
+          "columns": [
+            {
+              "expression": "external_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_logs_channel_id_channels_id_fk": {
+          "name": "usage_logs_channel_id_channels_id_fk",
+          "tableFrom": "usage_logs",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_patterns": {
+      "name": "workflow_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern_hash": {
+          "name": "pattern_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_sequence": {
+          "name": "tool_sequence",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "generated_skill_id": {
+          "name": "generated_skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_patterns_channel_id_channels_id_fk": {
+          "name": "workflow_patterns_channel_id_channels_id_fk",
+          "tableFrom": "workflow_patterns",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_patterns_generated_skill_id_skills_id_fk": {
+          "name": "workflow_patterns_generated_skill_id_skills_id_fk",
+          "tableFrom": "workflow_patterns",
+          "tableTo": "skills",
+          "columnsFrom": ["generated_skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_patterns_channel_hash_unique": {
+          "name": "workflow_patterns_channel_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["channel_id", "pattern_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -113,6 +113,20 @@
       "when": 1775737713696,
       "tag": "0015_light_eternity",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1778457600000,
+      "tag": "0016_tool_policy_unique",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1778457700000,
+      "tag": "0017_conversations_unique_thread",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/conversations.ts
+++ b/packages/db/src/schema/conversations.ts
@@ -1,11 +1,11 @@
 import {
   boolean,
-  index,
   integer,
   jsonb,
   pgTable,
   text,
   timestamp,
+  unique,
   uuid,
 } from 'drizzle-orm/pg-core';
 import { channels } from './channels';
@@ -26,6 +26,6 @@ export const conversations = pgTable(
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index('conversations_channel_thread_idx').on(table.channelId, table.externalThreadId),
+    unique('conversations_channel_thread_unique').on(table.channelId, table.externalThreadId),
   ],
 );

--- a/packages/db/src/schema/conversations.ts
+++ b/packages/db/src/schema/conversations.ts
@@ -1,3 +1,4 @@
+import type { ConversationMessage } from '@personalclaw/shared';
 import {
   boolean,
   integer,
@@ -18,7 +19,7 @@ export const conversations = pgTable(
       .notNull()
       .references(() => channels.id, { onDelete: 'cascade' }),
     externalThreadId: text('external_thread_id').notNull(),
-    messages: jsonb('messages').notNull().default([]),
+    messages: jsonb('messages').$type<ConversationMessage[]>().notNull().default([]),
     summary: text('summary'),
     isCompacted: boolean('is_compacted').notNull().default(false),
     tokenCount: integer('token_count'),

--- a/packages/db/src/schema/tool-policies.ts
+++ b/packages/db/src/schema/tool-policies.ts
@@ -1,14 +1,26 @@
-import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
 import { channels } from './channels';
 import { mcpConfigs } from './mcp-configs';
 
-export const toolPolicies = pgTable('tool_policies', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  channelId: uuid('channel_id').references(() => channels.id, { onDelete: 'cascade' }),
-  mcpConfigId: uuid('mcp_config_id')
-    .notNull()
-    .references(() => mcpConfigs.id, { onDelete: 'cascade' }),
-  allowList: text('allow_list').array().notNull().default([]),
-  denyList: text('deny_list').array().notNull().default([]),
-  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-});
+export const toolPolicies = pgTable(
+  'tool_policies',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    channelId: uuid('channel_id').references(() => channels.id, { onDelete: 'cascade' }),
+    mcpConfigId: uuid('mcp_config_id')
+      .notNull()
+      .references(() => mcpConfigs.id, { onDelete: 'cascade' }),
+    allowList: text('allow_list').array().notNull().default([]),
+    denyList: text('deny_list').array().notNull().default([]),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('tool_policies_mcp_channel_unique')
+      .on(table.mcpConfigId, table.channelId)
+      .where(sql`${table.channelId} IS NOT NULL`),
+    uniqueIndex('tool_policies_mcp_channel_null_unique')
+      .on(table.mcpConfigId)
+      .where(sql`${table.channelId} IS NULL`),
+  ],
+);


### PR DESCRIPTION
## Summary

Fixes three race conditions reported in #11 by replacing read-modify-write
and check-then-act sequences with atomic database / Redis primitives.

- `MCPService.upsertToolPolicy` — single-statement `INSERT … ON CONFLICT
  DO UPDATE` against new partial unique indexes; concurrent upserts can
  no longer both see "no row" and both insert.
- `ConversationMemory.append` — server-side JSONB concat
  (`messages || EXCLUDED.messages`) inside a transaction; concurrent
  appends to the same `(channel_id, external_thread_id)` no longer lose
  each other's messages, and `token_count` is recomputed from the merged
  result.
- `checkRateLimit` — single Redis Lua script (`redis.eval`) for atomic
  `INCR` + `EXPIRE`; eliminates the immortal-key bug when a process
  crashes between the two commands and self-heals legacy keys with no
  TTL.

> Note: A previous implement attempt produced PR #59 from the same
> branch name. This PR is a fresh implementation pushed to
> `fix/race-conditions-issue-11-v2` per the bot's resumed-`ship`
> instruction.

## Changes

### Database schema & migrations
- New partial unique indexes on `tool_policies (mcp_config_id, channel_id)`
  — separate indexes for `channel_id IS NOT NULL` and `channel_id IS NULL`
  because Postgres treats NULLs as distinct in standard unique constraints.
- New unique constraint on `conversations (channel_id, external_thread_id)`
  replacing the redundant non-unique index.
- Both migrations include an in-place dedupe pre-step
  (`ROW_NUMBER() OVER (PARTITION BY …)`) so the index/constraint creation
  cannot fail on existing duplicate rows.

### API
- `mcp.service.ts` — branches on `channelId === null` to target the
  correct partial index via Drizzle's `targetWhere`. No preceding `select`.
- `memory/conversation.ts` — `append` now uses `db.transaction`,
  `INSERT … ON CONFLICT DO UPDATE`, and a follow-up
  `UPDATE token_count` derived from the row returned by `RETURNING`.
- `middleware/rate-limiter.ts` — Lua script defined at module scope,
  invoked via `redis.eval`, returning `[current, ttl]` in one round-trip.

### Tests
- All three suites updated for the new mock surface (transaction support
  for conversation, `onConflictDoUpdate` chain for MCP, `redis.eval` for
  rate-limiter). Added regression tests asserting:
  - `upsertToolPolicy` does not select first (atomic path), works for
    null and non-null channel scopes;
  - `append` runs in a transaction with `ON CONFLICT` and recomputes
    token count from merged messages;
  - rate limiter falls back gracefully when `eval` throws and tolerates
    string-typed numeric returns.
- `memory/__tests__/engine.test.ts` mock updated to expose
  `transaction`/`onConflictDoUpdate` for `MemoryEngine` callers.

## Files changed

- `packages/db/src/migrations/0016_tool_policy_unique.sql` · new partial unique indexes + dedupe for `tool_policies`
- `packages/db/src/migrations/0017_conversations_unique_thread.sql` · unique constraint + dedupe for `conversations`, drops redundant non-unique index
- `packages/db/src/migrations/meta/_journal.json` · register migrations 0016 and 0017
- `packages/db/src/migrations/meta/0017_snapshot.json` · regenerated snapshot reflecting post-0017 schema
- `packages/db/src/schema/tool-policies.ts` · declare partial unique indexes via `uniqueIndex(...).where(...)`
- `packages/db/src/schema/conversations.ts` · declare `unique(...)` constraint, drop redundant non-unique index
- `apps/api/src/services/mcp.service.ts` · atomic `INSERT ON CONFLICT DO UPDATE` with `targetWhere`
- `apps/api/src/services/__tests__/mcp.service.test.ts` · mock `onConflictDoUpdate`, add null-channel + no-select-first tests
- `apps/api/src/memory/conversation.ts` · transaction-wrapped JSONB-concat upsert + token-count recompute
- `apps/api/src/memory/__tests__/conversation.test.ts` · transaction + ON CONFLICT mocks, recompute regression test
- `apps/api/src/memory/__tests__/engine.test.ts` · expose `transaction` and `onConflictDoUpdate` on the shared mock db
- `apps/api/src/middleware/rate-limiter.ts` · single-round-trip Lua-script `eval`
- `apps/api/src/middleware/__tests__/rate-limiter.test.ts` · `eval` mock, eval-throws fallback, string-number coercion test

## Commits

- `2db1dfb` · feat(db): unique constraints on tool_policies and conversations
- `32da5cc` · fix(mcp): atomic upsertToolPolicy via INSERT ON CONFLICT
- `8082003` · fix(memory): atomic JSONB concat in ConversationMemory.append
- `4897c68` · fix(middleware): atomic rate-limit INCR/EXPIRE via Lua script

## Tests run

- `bun run check` (typecheck + lint + all unit tests across `@personalclaw/api`, `@personalclaw/web`, `@personalclaw/shared`, `@personalclaw/db`) · ✅ pass (exit 0)
- 115 API test files passed (incl. `mcp.service.test.ts`, `conversation.test.ts`, `rate-limiter.test.ts`, `engine.test.ts`)
- 93 web tests passed
- 1 pre-existing biome warning in `apps/api/src/cron/__tests__/audit-cleanup.test.ts` (unsafe-fix; not introduced here)

## Diagram

```mermaid
sequenceDiagram
    participant R1 as Request 1
    participant R2 as Request 2
    participant DB as Postgres

    Note over R1,R2: ConversationMemory.append (after fix)
    R1->>DB: BEGIN; INSERT ... ON CONFLICT DO UPDATE<br/>SET messages = messages || EXCLUDED.messages
    DB-->>R1: row lock acquired, RETURNING [m1,m2,m3]
    R2->>DB: BEGIN; INSERT ... ON CONFLICT DO UPDATE
    Note over DB: R2 waits on row lock
    R1->>DB: UPDATE token_count = recompute([m1,m2,m3]); COMMIT
    DB-->>R2: row lock released
    DB-->>R2: concat applied: RETURNING [m1,m2,m3,m4]
    R2->>DB: UPDATE token_count = recompute([m1,m2,m3,m4]); COMMIT
    Note over DB: final state preserves both writers' messages
```

## Verification

1. `bun run check` passes locally on this branch.
2. Migrations 0016 and 0017 are idempotent (`CREATE UNIQUE INDEX IF NOT
   EXISTS` and `DELETE … WHERE rn > 1`); they will not fail if duplicates
   already exist or if the migration is re-applied.
3. `getToolPolicy`'s public signature is unchanged; `upsertToolPolicy`
   still returns the policy row; `append` still returns
   `{ tokenCount }`; `checkRateLimit` still returns
   `RateLimitResult` — no caller signature changes.
4. The Drizzle snapshot was regenerated to match the new schema, so
   subsequent `db:generate` runs will not produce an unexpected drift
   migration.

Closes #11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced data integrity with unique constraints on conversations and tool policies, preventing duplicate entries.
  * Improved reliability of message handling in conversations by using atomic database operations to prevent race conditions.
  * Optimized rate limiting implementation for improved consistency and performance.

* **Database Migrations**
  * Added migration to enforce unique conversation identifiers.
  * Added migration to enforce unique tool policy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->